### PR TITLE
Adds port support for postgresql connection

### DIFF
--- a/ua2sql.py
+++ b/ua2sql.py
@@ -85,8 +85,12 @@ transaction_table = Table('transaction', metadata,
                           Column('receipt', postgresql.JSONB)
                           )
 
-engine = create_engine('postgresql+psycopg2://' + CONFIG['user'] + ':' + CONFIG['password'] + '@'
-                       + CONFIG['postgres_server'] + '/' + CONFIG['database'])
+url = 'postgresql+psycopg2://' + CONFIG['user'] + ':' + CONFIG['password'] + '@' + CONFIG['postgres_server'] 
+if len(CONFIG['port']) > 0:
+	url += ':' + CONFIG['port']
+url += '/' + CONFIG['database'];
+engine = create_engine(url)
+
 conn = engine.connect()
 metadata.create_all(engine)
 


### PR DESCRIPTION
While getting ua2sql to run on my Synology RS815+, the Debian installation had put our postgresql installation on port 5433 as opposed to the default port 5432. With this modification, the script will support postgresql installations on other ports.

Please note, in order to add the port, it must be appened to the config.json that is passed into ua2sql.py:
```json
{
    ...
    "port": "5433",
    ...
}
```